### PR TITLE
#17 - 공통코드 auditingFields 추출

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,5 @@ Temporary Items
 
 ### VS Code ###
 .vscode/
+
+project_board/.idea/inspectionProfiles/Project_Default.xml

--- a/project_board/src/main/java/com/bitstudy/app/domain/Article.java
+++ b/project_board/src/main/java/com/bitstudy/app/domain/Article.java
@@ -23,6 +23,20 @@ import java.util.Set;
 *   3) 동등성, 동일성 비교할 수 있는 코드 넣기
 * */
 
+/*  중복코드 관리
+*   Article과 Comment 에 있는 공통 필드(메타데이터, ID제외)들을 별도로 빼서 관리할거임.
+*   이유는 앞으로 Article과 Comment처럼 엮여있는 테이블 만들경우, 모든 domain 안의 파일에 많은 중복코드가 들어감.
+*   그래서 별도 파일에 공통되는거 다 몰아넣고 사용해보기
+*
+*   추출법
+*   1) @Embedded : 공통되는 필드들을 하나의 클래스로 만들고 @Embedded 있는 곳에서 치환하는 방식
+*           Class Tmp{}
+*           @Embedded
+*           Tmp tmp;
+*
+*  *2) @MappedSuperClass : 어노테이션이 붙은곳에서 사용
+*
+* */
 
 @EntityListeners(AuditingEntityListener.class) //얘없으면 테스트 중 createAt 때문에 에러남(Ex04관련)
 
@@ -41,7 +55,7 @@ import java.util.Set;
 @Entity
 @Getter
 @ToString
-public class Article {
+public class Article extends AuditingFields {
 
     @Id //PK 지정 어노테이션
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/project_board/src/main/java/com/bitstudy/app/domain/AuditingFields.java
+++ b/project_board/src/main/java/com/bitstudy/app/domain/AuditingFields.java
@@ -1,0 +1,45 @@
+package com.bitstudy.app.domain;
+
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+/*  할일 : Article, Comment 의 중복필드 합치기
+    1) Article 의 메타데이터들(auditing 관련 필드) 가져오기
+    2) 클래스에 @MappedSuperclass 달아주기
+    3) auditing 관련된 것들 다 가져오기
+    4)
+*
+* */
+
+@EntityListeners(AuditingEntityListener.class) //얘없으면 테스트 중 createAt 때문에 에러남(Ex04관련)
+@MappedSuperclass
+@Getter
+@ToString
+public class AuditingFields {
+    //메타데이터
+    @CreatedDate
+    @Column(nullable = false)
+    private LocalDateTime create_at;
+
+    @CreatedBy
+    @Column(nullable = false, length = 100)
+    private String create_by;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modify_at;
+
+    @LastModifiedBy
+    @Column(nullable = false, length = 100)
+    private String modify_by;
+}


### PR DESCRIPTION
#14 에서 DB 접근 방법을 세팅하고 테스트를 만든 내용을 토대로 남은 구현이 있는지 확인하고 마무리 함.

생성자, 생성일, 수정자, 수정일은 반복적으로 엔티티 클래스에 들어가는 요소이고, 도메인과 직접 연관이 없는 메타데이터이므로 추출이 가능.

@MappedSuperclass를 이용해 상속방식으로 사용가능